### PR TITLE
Remove deploy from README and comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,3 @@ This project follows the [all-contributors](https://github.com/all-contributors/
 ## Building the documentation locally
 
 mkdocs serve
-
-## Update documentation in the server
-
-mkdocs gh-deploy

--- a/build_pdf/redborder_manual_book/en.yml
+++ b/build_pdf/redborder_manual_book/en.yml
@@ -40,5 +40,4 @@ nav:
   - ips/IPS_basics/ch1_what_is_redborder.md
   - ips/IPS_basics/ch2_redborder_installation.md
   - ips/platform_configurations/ips_sensor.md
-  # - guides
   


### PR DESCRIPTION
There's no need in manually do the deployment of the documentation since there is already a github action doing this.