### PR TITLE
Fix warnings when running mkdocs serve

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,8 +40,8 @@ markdown_extensions:
   - toc:
       permalink: true
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.highlight
   - pymdownx.superfences:
       custom_fences:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ site_url: "https://docs.redborder.com/"
 docs_dir: "docs"
 repo_url: https://github.com/redBorder/redborder-documentation
 repo_name: redBorder/redborder-documentation
-edit_url: "edit/master/docs"
+edit_uri: edit/master/docs
 
 theme:
   name: material


### PR DESCRIPTION
- Fixed deprecated library by pointing to different source
- Fixed 'url' issue renaming to 'uri'
- 