### PR TITLE
hide all malware references (at least in text)

### DIFF
--- a/docs/ips/IPS_basics/ch1_what_is_redborder.es.md
+++ b/docs/ips/IPS_basics/ch1_what_is_redborder.es.md
@@ -26,7 +26,7 @@ Para el **Manager**, al no ser necesario un hardware específico, la única cond
 * De esta manera se permite la creación de un bonding para la gestión y conexión con los sensores y otro bonding (opcional) para sus comunicaciones hacia otras redes. Ambos sistemas soportan el estándar 802.1q para virtual LAN (opcional a la hora de configurar).
 	
 !!! warning "Si no ha instalado el manager..."
-	Es importante haber relizado la configuración del Manager (o cluster de managers) antes de configurar y registrar el primer sensor IPS. El Manager debe estar operativo y en una red accesible a los sensores. Algunos de los procesos de configuración de los sensores dependen del acceso al Manager. El escenario de instalación del Manager redBorder es el mismo independientemente de los sensores que se instalen y registren en el mismo IPS, Flow, Malware (WIP) o Vault
+	Es importante haber relizado la configuración del Manager (o cluster de managers) antes de configurar y registrar el primer sensor IPS. El Manager debe estar operativo y en una red accesible a los sensores. Algunos de los procesos de configuración de los sensores dependen del acceso al Manager. El escenario de instalación del Manager redBorder es el mismo independientemente de los sensores que se instalen y registren en el mismo IPS, Flow o Vault
 
 ![Escenario básico para la instalación del IPS](../../manager/redborder_basics/images/ch01_img001.png)
 

--- a/docs/ips/IPS_basics/ch1_what_is_redborder.md
+++ b/docs/ips/IPS_basics/ch1_what_is_redborder.md
@@ -26,7 +26,7 @@ For the **Manager**, specific hardware is not required; the only condition is th
 * This allows for the creation of a bonding for management and connection with the sensors and another bonding (optional) for communications to other networks. Both systems support the 802.1q standard for virtual LAN (optional when configuring).
 
 !!! warning "If you have not installed the manager..."
-    It is important to configure the Manager (or cluster of managers) before configuring and registering the first IPS sensor. The Manager must be operational and on a network accessible to the sensors. Some sensor configuration processes depend on access to the Manager. The installation scenario of the Redborder Manager is the same regardless of the sensors that are installed and registered (IPS, Flow, Malware (WIP), or Vault).
+    It is important to configure the Manager (or cluster of managers) before configuring and registering the first IPS sensor. The Manager must be operational and on a network accessible to the sensors. Some sensor configuration processes depend on access to the Manager. The installation scenario of the Redborder Manager is the same regardless of the sensors that are installed and registered (IPS, Flow, or Vault).
 
 ![Basic Scenario for IPS Installation](../../manager/redborder_basics/images/ch01_img001.png)
 

--- a/docs/manager/more_in_detail/ch4_5_views.es.md
+++ b/docs/manager/more_in_detail/ch4_5_views.es.md
@@ -77,7 +77,7 @@ Mediante la vista **Único** el usuario puede obtener información sobre los dif
 
 Vista *único*
 
-## Analizar (Módulo Malware, WIP)
+<!-- ## Analizar (Módulo Malware, WIP)
 
 En esta vista se puede obtener un análisis detallado de una URL, IP, Hash o bien, de un fichero bajo demanda, como si este hubiera entrado por otros canales.
 
@@ -87,4 +87,4 @@ Puede saltar de una vista a otra sin necesidad de regresar a la interfaz de even
 
 ![Vista analizar](images/ch04_img047.png)
 
-Vista *analizar*
+Vista *analizar* -->

--- a/docs/manager/more_in_detail/ch4_5_views.md
+++ b/docs/manager/more_in_detail/ch4_5_views.md
@@ -77,7 +77,7 @@ Through the **Unique** view, the user can obtain information about the different
 
 *Unique* view
 
-## Analyze (Malware module, WIP)
+<!-- ## Analyze (Malware module, WIP)
 
 In this view, you can get a detailed analysis of a URL, IP, Hash, or a file, as if it had entered through other channels.
 
@@ -87,4 +87,4 @@ You can jump from one view to another without needing to go back to the Malware 
 
 ![Analyze View](images/ch04_img047.png)
 
-*Analyze* view
+*Analyze* view -->

--- a/docs/manager/more_in_detail/ch5_dashboards.es.md
+++ b/docs/manager/more_in_detail/ch5_dashboards.es.md
@@ -95,7 +95,7 @@ El primer paso es seleccionar el tipo de widget que desea agregar. Existen tres 
     - Tráfico
     - Intrusión
     - Movilidad
-    - Malware
+    <!-- - Malware -->
     - Vault
     - Wireless
     - Combinación
@@ -197,7 +197,7 @@ Para ingresar cualquiera de estos elementos a los widgets, simplemente complete 
 
 ![Edición de widgets de formato](images/ch05_img013.png)
 
-### Widgets de malware
+<!-- ### Widgets de malware
 
 Los widget de tipo Malware se asocian al análisis de eventos Malware ocurridos en cualquier parte de la infraestructura redborder.
 
@@ -209,7 +209,7 @@ Pueden resumirse en la siguiente lista:
 
 1. *Score average per hour*: puntuación media de los eventos de malware detectados en las últimas 24 horas.
 - *Malware Fast Search*: widget que permite la busqueda de un evento malware por hash, url o ip.
-- *Recent Malware*: muestra eventos de malware detectados en las últimas 24 horas.
+- *Recent Malware*: muestra eventos de malware detectados en las últimas 24 horas. -->
 
 ### Máquina del tiempo
 

--- a/docs/manager/more_in_detail/ch5_dashboards.md
+++ b/docs/manager/more_in_detail/ch5_dashboards.md
@@ -96,7 +96,7 @@ The first step is to select the type of widget you want to add. There are three 
    - Traffic
    - Intrusion
    - Mobility
-   - Malware
+   <!-- - Malware -->
    - Vault
    - Wireless
    - Combined 
@@ -192,7 +192,7 @@ To input any of these elements to the widgets, simply fill out the form that app
 
 ![Edit Format Widgets](images/ch05_img013.png)
 
-### Malware Widgets
+<!-- ### Malware Widgets
 
 Malware type widgets are associated with the analysis of Malware events occurring anywhere in the redborder infrastructure.
 
@@ -202,7 +202,7 @@ They can be summarized in the following list:
 
 1. *Score average per hour*: Average score of detected malware events in the last 24 hours.
 2. *Malware Fast Search*: Widget allowing the search of a malware event by hash, URL, or IP.
-3. *Recent Malware*: Displays malware events detected in the last 24 hours.
+3. *Recent Malware*: Displays malware events detected in the last 24 hours. -->
 
 ### Time Machine
 

--- a/docs/manager/redborder_basics/ch1_what_is_redborder.es.md
+++ b/docs/manager/redborder_basics/ch1_what_is_redborder.es.md
@@ -14,7 +14,7 @@ Las sondas se sitúan fuera de la plataforma, pero se gestionan desde ella y su 
 Dependiendo de las aplicaciones integradas en la plataforma, el usuario verá una u otras opciones en la barra de menú. Las aplicaciones que están disponibles en esta nueva versión de Redborder son las siguientes:
 
 - Business Intelligence
-- Malware
+<!-- - Malware -->
 - Tráfico
 - Intrusión
 - Monitor

--- a/docs/manager/redborder_basics/ch1_what_is_redborder.md
+++ b/docs/manager/redborder_basics/ch1_what_is_redborder.md
@@ -14,7 +14,7 @@ Probes are located outside the platform but are managed from it, and their funct
 Depending on the applications integrated into the platform, the user will see different options in the menu bar. The applications available in this new version of Redborder are as follows:
 
 - Business Intelligence
-- Malware
+<!-- - Malware -->
 - Traffic
 - Intrusion
 - Monitor

--- a/docs/manager/redborder_basics/ch4_1_modules.es.md
+++ b/docs/manager/redborder_basics/ch4_1_modules.es.md
@@ -19,7 +19,7 @@ Este módulo viene desactivado por defecto, para activarlo ejecute el siguiente 
 
 Módulo de BI
 
-## Malware (WIP)
+<!-- ## Malware (WIP)
 
 El módulo **Malware** es una solución completa para la detección de archivos, direcciones IP y direcciones URL maliciosas. Para ello se emplean múltiples motores de detección y servicios de reputación que van más allá de las políticas basadas en firmas y técnicas similares.
 
@@ -29,7 +29,7 @@ Este módulo viene desactivado por defecto, para activarlo ejecute el siguiente 
 
 ![Módulo de Malware](images/ch04_img002.png)
 
-Módulo de Malware
+Módulo de Malware -->
 
 ## Tráfico
 

--- a/docs/manager/redborder_basics/ch4_1_modules.md
+++ b/docs/manager/redborder_basics/ch4_1_modules.md
@@ -19,7 +19,7 @@ This module is disabled by default, to activate it, run the following command fr
 
 BI module
 
-## Malware (WIP)
+<!-- ## Malware (WIP)
 
 The **Malware** module is a complete solution for detecting malicious files, IP addresses, and URLs. Multiple detection engines and reputation services are employed, going beyond signature-based policies and similar techniques.
 
@@ -29,7 +29,7 @@ This module is disabled by default, to activate it, run the following command fr
 
 ![Malware Module](images/ch04_img002.png)
 
-Malware Module
+Malware Module -->
 
 ## Traffic
 

--- a/docs/manager/redborder_basics/ch4_2_modules_menu_options.es.md
+++ b/docs/manager/redborder_basics/ch4_2_modules_menu_options.es.md
@@ -170,13 +170,13 @@ Si desea ver las categorías de atributos disponibles, despliegue esta pestaña:
         - Red
         - Transporte
         - UUIDs
-
+<!-- 
     === "Categorías de Malware"
 
         - Email
         - Archivo
         - Malware
-        - Red
+        - Red -->
 
 ![Atributos](images/ch04_img022.png)
 

--- a/docs/manager/redborder_basics/ch4_2_modules_menu_options.md
+++ b/docs/manager/redborder_basics/ch4_2_modules_menu_options.md
@@ -172,13 +172,13 @@ If you want to see the available attribute categories, expand this tab:
         - Network
         - Transport
         - UUIDs
-
+<!-- 
     === "Malware Categories"
 
         - Email
         - File
         - Malware
-        - Network
+        - Network -->
 
 ![Attributes](images/ch04_img022.png)
 


### PR DESCRIPTION
Commented malware references to be added later when gets fixed for NG.
Malware was a module in legacy redborder... :book: :sleeping: 